### PR TITLE
remove registerWith method

### DIFF
--- a/android/src/main/java/yeniellandestoy/native_shared_preferences/NativeSharedPreferencesPlugin.java
+++ b/android/src/main/java/yeniellandestoy/native_shared_preferences/NativeSharedPreferencesPlugin.java
@@ -12,11 +12,6 @@ public class NativeSharedPreferencesPlugin implements FlutterPlugin {
   private static final String CHANNEL_NAME = "native_shared_preferences";
   private MethodChannel channel;
 
-  public static void registerWith(PluginRegistry.Registrar registrar) {
-    final NativeSharedPreferencesPlugin plugin = new NativeSharedPreferencesPlugin();
-    plugin.setupChannel(registrar.messenger(), registrar.context());
-  }
-
   @Override
   public void onAttachedToEngine(FlutterPlugin.FlutterPluginBinding binding) {
     setupChannel(binding.getBinaryMessenger(), binding.getApplicationContext());


### PR DESCRIPTION
Removed registerWith method that uses removed apis. This should fix the issue with android app not building with Flutter 3.29.0 and later versions